### PR TITLE
사진 업로드 API 구현

### DIFF
--- a/api/forms.py
+++ b/api/forms.py
@@ -18,6 +18,11 @@ class PostForm(forms.Form):
     media = forms.CharField()
     userId = forms.UUIDField()
 
+
 class ReplyForm(forms.Form):
     postId = forms.UUIDField()
     text = forms.CharField()
+
+
+class UploadForm(forms.Form):
+    file = forms.FileField()

--- a/api/routes/upload.py
+++ b/api/routes/upload.py
@@ -1,0 +1,39 @@
+import os
+from datetime import datetime
+
+import boto3
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from ..errors import VALIDATION_ERROR
+from ..forms import UploadForm
+from ..utils import make_response_payload, require_token
+
+REGION_NAME = "ap-northeast-2"
+BUCKET_NAME = "sustagram"
+
+session = boto3.Session(
+    aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+    aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+    region_name=REGION_NAME
+)
+s3 = session.resource('s3')
+
+
+class UploadAPI(APIView):
+    @require_token
+    def post(self, request):
+        form = UploadForm(request.POST, request.FILES)
+
+        if not form.is_valid():
+            return Response(make_response_payload(is_success=False, message=VALIDATION_ERROR), status=400)
+
+        file = request.FILES['file']
+        dt_string = datetime.now().strftime("%Y%m%d%M%M%S")
+        file_name = f'{dt_string}-{file.name}'
+
+        s3.Object(BUCKET_NAME, file_name).put(Body=file)
+
+        file_url = f"https://s3.ap-northeast-2.amazonaws.com/{BUCKET_NAME}/{file_name}"
+
+        return Response(make_response_payload(file_url), status=201)

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .routes import auth, post, follow, reply, like
+from .routes import auth, post, follow, reply, like, upload
 
 urlpatterns = [
     path('register/', auth.Register.as_view()),
@@ -17,5 +17,7 @@ urlpatterns = [
     path('reply/<str:post_id>', reply.ReplyAPI.as_view()),
     path('reply/', reply.ReplyAPINotParams.as_view()),
 
-    path('like/<str:post_id>', like.LikeAPI.as_view())
+    path('like/<str:post_id>', like.LikeAPI.as_view()),
+
+    path('upload/', upload.UploadAPI.as_view())
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 asgiref==3.2.10
 attrs==20.3.0
+boto3==1.16.24
+botocore==1.19.24
 certifi==2020.11.8
 chardet==3.0.4
 coreapi==2.3.3
@@ -14,6 +16,7 @@ importlib-metadata==2.0.0
 inflection==0.5.1
 itypes==1.2.0
 Jinja2==2.11.2
+jmespath==0.10.0
 jsonschema==3.2.0
 MarkupSafe==1.1.1
 mysqlclient==2.0.1
@@ -21,11 +24,13 @@ packaging==20.4
 PyJWT==1.7.1
 pyparsing==2.4.7
 pyrsistent==0.17.3
+python-dateutil==2.8.1
 pytz==2020.1
 PyYAML==5.3.1
 requests==2.25.0
 ruamel.yaml==0.16.12
 ruamel.yaml.clib==0.2.2
+s3transfer==0.3.3
 six==1.15.0
 sqlparse==0.3.1
 swagger-spec-validator==2.7.3


### PR DESCRIPTION
S3를 이용하여 사진 업로드 API를 구현했습니다.

### `POST` /api/upload/
- `Content-Type`을 `multipart/form-data`으로 설정해서 사용 가능합니다.
- 성공 시 업로드 된 이미지의 링크를 data 값으로 반환합니다.
```
Body
{
    file: <File>
}
```
```
Response
{
    success: Boolean,
    data: ImageURL
}
```